### PR TITLE
support batch in identifier apis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaius/node-sdk",
-  "version": "0.5.15",
+  "version": "0.6.0",
   "description": "Node SDK for Zaius Apps",
   "repository": "https://github.com/ZaiusInc/node-sdk",
   "license": "UNLICENSED",

--- a/src/Api/Identifiers/consent.test.ts
+++ b/src/Api/Identifiers/consent.test.ts
@@ -1,8 +1,10 @@
 import 'jest';
+import * as nock from 'nock';
 import {InternalConfig} from '../config/configure';
 import {ApiV3} from '../lib/ApiV3';
 import {ConsentUpdate} from '../Types';
 import {getConsent, updateConsent} from './consent';
+import deepFreeze = require('deep-freeze');
 
 const mockConfiguration: InternalConfig = {
   trackerId: 'vdl',
@@ -17,63 +19,99 @@ describe('consent', () => {
 
   describe('updateConsent', () => {
     it('sends a post to /consent', async () => {
-      const postFn = jest.spyOn(ApiV3, 'post').mockResolvedValueOnce({} as any);
       const update: ConsentUpdate = Object.freeze({
+        identifier_field_name: 'email',
+        identifier_value: 'foo@zaius.com',
         consent: false,
         consent_update_reason: 'preference center update'
       });
-      await updateConsent('email', 'foo@zaius.com', update);
-      expect(postFn).toHaveBeenCalledWith('/consent', {
-        ...update,
-        identifier_field_name: 'email',
-        identifier_value: 'foo@zaius.com'
-      });
-      postFn.mockRestore();
+      nock('https://api.zaius.com')
+        .post('/v3/consent', [update] as any)
+        .reply(200, '{}');
+      await updateConsent(update);
+      expect(nock.isDone()).toBeTruthy();
+    });
+
+    it('handles multiple updates', async () => {
+      const update = deepFreeze([
+        {
+          identifier_field_name: 'email',
+          identifier_value: 'foo@zaius.com',
+          consent: false,
+          consent_update_reason: 'preference center update'
+        },
+        {
+          identifier_field_name: 'email',
+          identifier_value: 'bar@zaius.com',
+          consent: false,
+          consent_update_reason: 'other'
+        }
+      ]) as ConsentUpdate[];
+      nock('https://api.zaius.com')
+        .post('/v3/consent', update as any)
+        .reply(200, '{}');
+      await updateConsent(update);
+      expect(nock.isDone()).toBeTruthy();
     });
 
     it('throws an error if the api returns an error', async () => {
-      const postFn = jest
-        .spyOn(ApiV3, 'post')
-        .mockRejectedValueOnce(new ApiV3.HttpError('Bad Request', undefined, {} as any));
       const update: ConsentUpdate = {
+        identifier_field_name: 'email',
+        identifier_value: 'foo@zaius.com',
         consent: false
       };
-      await expect(updateConsent('email', 'foo@zaius.com', update)).rejects.toThrowError('Bad Request');
-      postFn.mockRestore();
+      nock('https://api.zaius.com')
+        .post('/v3/consent', [update] as any)
+        .reply(400, '{}');
+      await expect(updateConsent(update)).rejects.toThrowError('Bad Request');
+      expect(nock.isDone()).toBeTruthy();
+    });
+
+    it('throws an error if the batch is too large', async () => {
+      const updates = Array(101).fill({
+        identifier_field_name: 'email',
+        identifier_value: 'foo@zaius.com',
+        consent: true
+      });
+      await expect(updateConsent(updates)).rejects.toThrowError('maximum batch size');
     });
 
     it('formats date if provided as a Date object', async () => {
-      const postFn = jest.spyOn(ApiV3, 'post').mockResolvedValueOnce({} as any);
       jest.spyOn(Date.prototype, 'toISOString').mockReturnValueOnce('2020-01-21T23:07:54.373Z');
       const update: ConsentUpdate = Object.freeze({
+        identifier_field_name: 'email',
+        identifier_value: 'foo@zaius.com',
         consent: false,
         consent_update_reason: 'preference center update',
         consent_update_ts: new Date()
       });
-      await updateConsent('email', 'foo@zaius.com', update);
-      expect(postFn).toHaveBeenCalledWith('/consent', {
+      const expectedUpdate: ConsentUpdate = {
         ...update,
-        identifier_field_name: 'email',
-        identifier_value: 'foo@zaius.com',
         consent_update_ts: '2020-01-21T23:07:54.373Z'
-      });
-      postFn.mockRestore();
+      };
+      nock('https://api.zaius.com')
+        .post('/v3/consent', [expectedUpdate] as any)
+        .reply(200, '{}');
+      await updateConsent(update);
+      expect(nock.isDone()).toBeTruthy();
     });
   });
 
   describe('getConsent', () => {
-    it('sends a get to /consent/{identifier}', async () => {
-      const getFn = jest.spyOn(ApiV3, 'get').mockResolvedValueOnce({} as any);
+    it('sends a get to /reachability/{identifier}', async () => {
+      nock('https://api.zaius.com')
+        .get('/v3/consent/email?id=foo%40zaius.com')
+        .reply(200, '{}');
       await getConsent('email', 'foo@zaius.com');
-      expect(getFn).toHaveBeenCalledWith('/consent/email?id=foo%40zaius.com');
-      getFn.mockRestore();
+      expect(nock.isDone()).toBeTruthy();
     });
 
     it('safely encodes url values', async () => {
-      const getFn = jest.spyOn(ApiV3, 'get').mockResolvedValueOnce({} as any);
+      nock('https://api.zaius.com')
+        .get('/v3/consent/em%20ail?id=%22foo%22%40zaius.com')
+        .reply(200, '{}');
       await getConsent('em ail', '"foo"@zaius.com');
-      expect(getFn).toHaveBeenCalledWith('/consent/em%20ail?id=%22foo%22%40zaius.com');
-      getFn.mockRestore();
+      expect(nock.isDone()).toBeTruthy();
     });
   });
 });

--- a/src/Api/Identifiers/consent.ts
+++ b/src/Api/Identifiers/consent.ts
@@ -3,25 +3,34 @@ import {ConsentUpdate, GetConsentResponse} from '../Types';
 
 /**
  * Update consent of a messaging identifier
- * @param identifierFieldName The name of the messaging identifier field you want to update, e.g., email
- * @param identifierValue A valid messaging identifier value, such as an email address for the email identifier
- * @param update the update to perform
+ * @param updates one or more updates to consent for specific identifier values
  * @throws {HttpError} if it receives any non-2XX result
  */
 export async function updateConsent(
-  identifierFieldName: string,
-  identifierValue: string,
-  update: ConsentUpdate
+  updates: ConsentUpdate | ConsentUpdate[]
 ): Promise<ApiV3.HttpResponse<ApiV3.V3SuccessResponse>> {
-  const request = {
-    ...update,
-    identifier_field_name: identifierFieldName,
-    identifier_value: identifierValue
-  };
-  if (update.consent_update_ts instanceof Date) {
-    request.consent_update_ts = update.consent_update_ts.toISOString();
+  if (!Array.isArray(updates)) {
+    updates = [updates];
   }
-  return await ApiV3.post('/consent', request);
+
+  if (updates.length > ApiV3.BATCH_LIMIT) {
+    throw ApiV3.errorForCode(ApiV3.ErrorCode.BatchLimitExceeded);
+  }
+
+  // if we're going to make changes, clone the array first
+  if (updates.some((u) => u.consent_update_ts instanceof Date)) {
+    updates = [...updates];
+  }
+
+  for (let i = 0; i < updates.length; i++) {
+    const update = updates[i];
+    if (update.consent_update_ts instanceof Date) {
+      // create a new object to not modify the incoming object
+      updates[i] = {...update, consent_update_ts: update.consent_update_ts.toISOString()};
+    }
+  }
+
+  return await ApiV3.post('/consent', updates);
 }
 
 /**

--- a/src/Api/Identifiers/identifiers.test.ts
+++ b/src/Api/Identifiers/identifiers.test.ts
@@ -17,15 +17,51 @@ describe('identifiers', () => {
   describe('updateMetadata', () => {
     it('sends a post to /identifiers', async () => {
       const postFn = jest.spyOn(ApiV3, 'post').mockResolvedValueOnce({} as any);
-      await updateMetadata('email', 'foo@zaius.com', {foo: 'bar'});
-      expect(postFn).toHaveBeenCalledWith('/identifiers', {
+      await updateMetadata({identifier_field_name: 'email', identifier_value: 'foo@zaius.com', metadata: {foo: 'bar'}});
+      expect(postFn).toHaveBeenCalledWith('/identifiers', [
+        {
+          identifier_field_name: 'email',
+          identifier_value: 'foo@zaius.com',
+          metadata: {
+            foo: 'bar'
+          }
+        }
+      ]);
+      postFn.mockRestore();
+    });
+
+    it('sends a batch to /identifiers', async () => {
+      const postFn = jest.spyOn(ApiV3, 'post').mockResolvedValueOnce({} as any);
+      await updateMetadata([
+        {identifier_field_name: 'email', identifier_value: 'foo@zaius.com', metadata: {foo: 'foo'}},
+        {identifier_field_name: 'email', identifier_value: 'bar@zaius.com', metadata: {foo: 'bar'}}
+      ]);
+      expect(postFn).toHaveBeenCalledWith('/identifiers', [
+        {
+          identifier_field_name: 'email',
+          identifier_value: 'foo@zaius.com',
+          metadata: {
+            foo: 'foo'
+          }
+        },
+        {
+          identifier_field_name: 'email',
+          identifier_value: 'bar@zaius.com',
+          metadata: {
+            foo: 'bar'
+          }
+        }
+      ]);
+      postFn.mockRestore();
+    });
+
+    it('throws an error if the batch is too large', async () => {
+      const updates = Array(101).fill({
         identifier_field_name: 'email',
         identifier_value: 'foo@zaius.com',
-        metadata: {
-          foo: 'bar'
-        }
+        metadata: {foo: 'foo'}
       });
-      postFn.mockRestore();
+      await expect(updateMetadata(updates)).rejects.toThrowError('maximum batch size');
     });
   });
 

--- a/src/Api/Identifiers/identifiers.ts
+++ b/src/Api/Identifiers/identifiers.ts
@@ -3,22 +3,21 @@ import {IdentifierMetadata, IdentifierMetadataResponse} from '../Types';
 
 /**
  * Update metadata for a customer's identifier
- * @param identifierFieldName The name of the identifier field you want to update, e.g., email
- * @param identifierValue An existing identifier value, such as a known email address
- * @param update the update to perform
+ * @param updates one or more metadata updates for specific identifier values
  * @throws {HttpError} if it receives any non-2XX result
  */
 export async function updateMetadata(
-  identifierFieldName: string,
-  identifierValue: string,
-  metadata: IdentifierMetadata
+  updates: IdentifierMetadata | IdentifierMetadata[]
 ): Promise<ApiV3.HttpResponse<ApiV3.V3SuccessResponse>> {
-  const request = {
-    identifier_field_name: identifierFieldName,
-    identifier_value: identifierValue,
-    metadata
-  };
-  return await ApiV3.post('/identifiers', request);
+  if (!Array.isArray(updates)) {
+    updates = [updates];
+  }
+
+  if (updates.length > ApiV3.BATCH_LIMIT) {
+    throw ApiV3.errorForCode(ApiV3.ErrorCode.BatchLimitExceeded);
+  }
+
+  return await ApiV3.post('/identifiers', updates);
 }
 
 /**

--- a/src/Api/Identifiers/reachability.test.ts
+++ b/src/Api/Identifiers/reachability.test.ts
@@ -1,8 +1,10 @@
 import 'jest';
+import * as nock from 'nock';
 import {InternalConfig} from '../config/configure';
 import {ApiV3} from '../lib/ApiV3';
 import {ReachabilityUpdate} from '../Types';
 import {getReachability, updateReachability} from './reachability';
+import deepFreeze = require('deep-freeze');
 
 const mockConfiguration: InternalConfig = {
   trackerId: 'vdl',
@@ -17,63 +19,99 @@ describe('reachability', () => {
     });
 
     it('sends a post to /reachability', async () => {
-      const postFn = jest.spyOn(ApiV3, 'post').mockResolvedValueOnce({} as any);
       const update: ReachabilityUpdate = Object.freeze({
+        identifier_field_name: 'email',
+        identifier_value: 'foo@zaius.com',
         reachable: false,
         reachable_update_reason: 'hard_bounce'
       });
-      await updateReachability('email', 'foo@zaius.com', update);
-      expect(postFn).toHaveBeenCalledWith('/reachability', {
-        ...update,
-        identifier_field_name: 'email',
-        identifier_value: 'foo@zaius.com'
-      });
-      postFn.mockRestore();
+      nock('https://api.zaius.com')
+        .post('/v3/reachability', [update] as any)
+        .reply(200, '{}');
+      await updateReachability(update);
+      expect(nock.isDone()).toBeTruthy();
+    });
+
+    it('handles multiple updates', async () => {
+      const update = deepFreeze([
+        {
+          identifier_field_name: 'email',
+          identifier_value: 'foo@zaius.com',
+          reachable: false,
+          reachable_update_reason: 'hard_bounce'
+        },
+        {
+          identifier_field_name: 'email',
+          identifier_value: 'bar@zaius.com',
+          reachable: true,
+          reachable_update_reason: 'hard_bounce'
+        }
+      ]) as ReachabilityUpdate[];
+      nock('https://api.zaius.com')
+        .post('/v3/reachability', update as any)
+        .reply(200, '{}');
+      await updateReachability(update);
+      expect(nock.isDone()).toBeTruthy();
     });
 
     it('throws an error if the api returns an error', async () => {
-      const postFn = jest
-        .spyOn(ApiV3, 'post')
-        .mockRejectedValueOnce(new ApiV3.HttpError('Bad Request', undefined, {} as any));
       const update: ReachabilityUpdate = {
+        identifier_field_name: 'email',
+        identifier_value: 'foo@zaius.com',
         reachable: false
       };
-      await expect(updateReachability('email', 'foo@zaius.com', update)).rejects.toThrowError('Bad Request');
-      postFn.mockRestore();
+      nock('https://api.zaius.com')
+        .post('/v3/reachability', [update] as any)
+        .reply(400, '{}');
+      await expect(updateReachability(update)).rejects.toThrowError('Bad Request');
+      expect(nock.isDone()).toBeTruthy();
+    });
+
+    it('throws an error if the batch is too large', async () => {
+      const updates = Array(101).fill({
+        identifier_field_name: 'email',
+        identifier_value: 'foo@zaius.com',
+        reachable: true
+      });
+      await expect(updateReachability(updates)).rejects.toThrowError('maximum batch size');
     });
 
     it('formats date if provided as a Date object', async () => {
-      const postFn = jest.spyOn(ApiV3, 'post').mockResolvedValueOnce({} as any);
       jest.spyOn(Date.prototype, 'toISOString').mockReturnValueOnce('2020-01-21T23:07:54.373Z');
       const update: ReachabilityUpdate = Object.freeze({
-        reachable: false,
-        reachable_update_reason: 'hard_bounce',
-        reachable_update_ts: new Date()
-      });
-      await updateReachability('email', 'foo@zaius.com', update);
-      expect(postFn).toHaveBeenCalledWith('/reachability', {
-        ...update,
         identifier_field_name: 'email',
         identifier_value: 'foo@zaius.com',
-        reachable_update_ts: '2020-01-21T23:07:54.373Z'
+        reachable: false,
+        reachable_update_reason: 'preference center update',
+        reachable_update_ts: new Date()
       });
-      postFn.mockRestore();
+      const expectedUpdate: ReachabilityUpdate = {
+        ...update,
+        reachable_update_ts: '2020-01-21T23:07:54.373Z'
+      };
+      nock('https://api.zaius.com')
+        .post('/v3/reachability', [expectedUpdate] as any)
+        .reply(200, '{}');
+      await updateReachability(update);
+      expect(nock.isDone()).toBeTruthy();
     });
   });
 
   describe('getReachability', () => {
     it('sends a get to /reachability/{identifier}', async () => {
-      const getFn = jest.spyOn(ApiV3, 'get').mockResolvedValueOnce({} as any);
+      nock('https://api.zaius.com')
+        .get('/v3/reachability/email?id=foo%40zaius.com')
+        .reply(200, '{}');
       await getReachability('email', 'foo@zaius.com');
-      expect(getFn).toHaveBeenCalledWith('/reachability/email?id=foo%40zaius.com');
-      getFn.mockRestore();
+      expect(nock.isDone()).toBeTruthy();
     });
 
     it('safely encodes url values', async () => {
-      const getFn = jest.spyOn(ApiV3, 'get').mockResolvedValueOnce({} as any);
+      nock('https://api.zaius.com')
+        .get('/v3/reachability/em%20ail?id=%22foo%22%40zaius.com')
+        .reply(200, '{}');
       await getReachability('em ail', '"foo"@zaius.com');
-      expect(getFn).toHaveBeenCalledWith('/reachability/em%20ail?id=%22foo%22%40zaius.com');
-      getFn.mockRestore();
+      expect(nock.isDone()).toBeTruthy();
     });
   });
 });

--- a/src/Api/Types/Consent.ts
+++ b/src/Api/Types/Consent.ts
@@ -6,6 +6,14 @@ import {EventData} from '.';
  */
 export interface ConsentUpdate {
   /**
+   * The name of the messaging identifier field you want to update, e.g., email
+   */
+  identifier_field_name: string;
+  /**
+   * A valid messaging identifier value, such as an email address for the email identifier
+   */
+  identifier_value: string;
+  /**
    * true indicates the customer consented to receive marketing communications on this identifier,
    * false indicates the customer has explicitly revoked consent to receive marketing communications, e.g.,
    * checked a box saying "I do not want to receive marketing communications."

--- a/src/Api/Types/Identifiers.ts
+++ b/src/Api/Types/Identifiers.ts
@@ -23,11 +23,24 @@ export interface Identifiers {
  */
 export interface IdentifierMetadata {
   /**
-   * The fields must already exist before updating.
-   * The value should be a string, number, or boolean value matching the metadata field type.
-   * An explicitly null value will remove the previous value.
+   * The name of the identifier field you want to update, e.g., email
    */
-  [field: string]: string | number | boolean | null;
+  identifier_field_name: string;
+  /**
+   * An existing identifier value, such as a known email address
+   */
+  identifier_value: string;
+  /**
+   * The metadata to update
+   */
+  metadata: {
+    /**
+     * The fields must already exist before updating.
+     * The value should be a string, number, or boolean value matching the metadata field type.
+     * An explicitly null value will remove the previous value.
+     */
+    [field: string]: string | number | boolean | null;
+  };
 }
 
 export interface IdentifierMetadataResponse {

--- a/src/Api/Types/Reachability.ts
+++ b/src/Api/Types/Reachability.ts
@@ -20,6 +20,14 @@ export type ReachabilityUpdateType =
  */
 export interface ReachabilityUpdate {
   /**
+   * The name of the messaging identifier field you want to update, e.g., email
+   */
+  identifier_field_name: string;
+  /**
+   * A valid messaging identifier value, such as an email address for the email identifier
+   */
+  identifier_value: string;
+  /**
    * true indicates the identifier value is now reachable, false indicates it is no longer reachable
    */
   reachable: boolean;


### PR DESCRIPTION
A mistake in my last story to add identifier APIs to the node SDK: i ignored/forgot about the batch use case and immediately regretted it.

So unfortunately this is a breaking change, but fortunately it's only been a couple days so the impact should be minor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaiusinc/node-sdk/23)
<!-- Reviewable:end -->
