### PR TITLE
preserved existing config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaiusinc/node-sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Node SDK for Zaius Apps",
   "repository": "https://github.com/ZaiusInc/node-sdk",
   "license": "UNLICENSED",

--- a/src/Api/config/configure.test.ts
+++ b/src/Api/config/configure.test.ts
@@ -20,4 +20,25 @@ describe('configure', () => {
     };
     expect(ApiV3.configure).toHaveBeenCalledWith(Object.assign(defaultConfig, configuration));
   });
+
+  it('reconfigures the api module by overriding the supplied config', () => {
+    const configuration = {
+      apiBasePath: 'https://api.zaius.com/v3/',
+      apiKey: 'pub_api_key'
+    };
+
+    configure(configuration);
+
+    // set by setup.ts
+    const defaultConfig = {
+      requestId: '00000000-0000-0000-0000-000000000000',
+      apiKey: 'private.api_key'
+    };
+
+    const initialConfig = Object.assign(defaultConfig, configuration);
+    expect(ApiV3.configure).toHaveBeenCalledWith(initialConfig);
+
+    configure({apiKey: 'updated'});
+    expect(ApiV3.configure).toHaveBeenCalledWith(Object.assign(initialConfig, {apiKey: 'updated'}));
+  });
 });

--- a/src/Api/config/configure.ts
+++ b/src/Api/config/configure.ts
@@ -60,7 +60,7 @@ export function configure(newConfig: Config | InternalConfig | null) {
   if (newConfig == null) {
     configuration = DEFAULT_CONFIG;
   } else {
-    configuration = Object.assign({}, DEFAULT_CONFIG, newConfig);
+    configuration = Object.assign({}, DEFAULT_CONFIG, configuration, newConfig);
   }
 
   ApiV3.configure(configuration);


### PR DESCRIPTION
Defect was uncovered here when configuring the node sdk to use a different api key.  This fix will preserve the existing configuration that was set by anduin.  Ultimately what happen was the config went back to the defaults those losing the staging v2 api base path and failing requests with 403 since staging trackers will attempted to be loaded in production argo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaiusinc/node-sdk/41)
<!-- Reviewable:end -->
