### PR TITLE
Initial support for GraphQL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ z.list.getLists(listName);
 z.list.subscribe(listId, identifiers);
 z.list.unsubscribe(listId, identifiers);
 z.list.updateSubscriptions(listId, arrayOfUpdates);
+
+/**
+ * Query data using the v3 GraphQL API
+ */
+z.graphql<ResponseType>(query, variables);
 ```
 
 ## Using new APIs or APIs not yet supported by the Node SDK

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ z.list.unsubscribe(listId, identifiers);
 z.list.updateSubscriptions(listId, arrayOfUpdates);
 
 /**
- * Query data using the v3 GraphQL API
+ * Query data using the GraphQL API
  */
 z.graphql<ResponseType>(query, variables);
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaiusinc/node-sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Node SDK for Zaius Apps",
   "repository": "https://github.com/ZaiusInc/node-sdk",
   "license": "Apache-2.0",

--- a/src/Api/GraphQL/graphql.test.ts
+++ b/src/Api/GraphQL/graphql.test.ts
@@ -12,4 +12,11 @@ describe('graphql', () => {
     await graphql(query);
     expect(requestMock).toHaveBeenCalledWith('POST', '/graphql', {query});
   });
+
+  it('sends a query with variables to /graphql', async () => {
+    const query = '{}';
+    const variables = {};
+    await graphql(query, variables);
+    expect(requestMock).toHaveBeenCalledWith('POST', '/graphql', {query, variables});
+  });
 });

--- a/src/Api/GraphQL/graphql.test.ts
+++ b/src/Api/GraphQL/graphql.test.ts
@@ -2,21 +2,32 @@ import {ApiV3} from '../lib/ApiV3';
 import {graphql} from './graphql';
 
 describe('graphql', () => {
-  let requestMock!: jest.Mock;
+  let postMock!: jest.Mock;
   beforeEach(() => {
-    requestMock = jest.spyOn(ApiV3, 'request').mockReturnValue(Promise.resolve({} as any));
+    postMock = jest.spyOn(ApiV3, 'post').mockReturnValue(Promise.resolve({} as any));
   });
 
   it('sends a query to /graphql', async () => {
     const query = '{}';
-    await graphql(query);
-    expect(requestMock).toHaveBeenCalledWith('POST', '/graphql', {query});
+    postMock.mockReturnValue({
+      success: true,
+      data: {
+        data: 'result data'
+      }
+    });
+    const result = await graphql(query);
+    expect(postMock).toHaveBeenCalledWith('/graphql', {query});
+    expect(result).toEqual({
+      success: true,
+      data: 'result data'
+    });
   });
 
   it('sends a query with variables to /graphql', async () => {
     const query = '{}';
     const variables = {};
+    postMock.mockReturnValue({ data: { data: 'result data' } });
     await graphql(query, variables);
-    expect(requestMock).toHaveBeenCalledWith('POST', '/graphql', {query, variables});
+    expect(postMock).toHaveBeenCalledWith('/graphql', {query, variables});
   });
 });

--- a/src/Api/GraphQL/graphql.test.ts
+++ b/src/Api/GraphQL/graphql.test.ts
@@ -1,0 +1,15 @@
+import {ApiV3} from '../lib/ApiV3';
+import {graphql} from './graphql';
+
+describe('graphql', () => {
+  let requestMock!: jest.Mock;
+  beforeEach(() => {
+    requestMock = jest.spyOn(ApiV3, 'request').mockReturnValue(Promise.resolve({} as any));
+  });
+
+  it('sends a query to /graphql', async () => {
+    const query = '{}';
+    await graphql(query);
+    expect(requestMock).toHaveBeenCalledWith('POST', '/graphql', {query});
+  });
+});

--- a/src/Api/GraphQL/graphql.ts
+++ b/src/Api/GraphQL/graphql.ts
@@ -1,0 +1,10 @@
+import { ApiV3 } from '../Types';
+import { Result } from '../Types/GraphQL';
+
+export async function graphql<T>(query: string): Promise<ApiV3.HttpResponse<Result<T>>> {
+  return ApiV3.request(
+    'POST',
+    '/graphql',
+    { query }
+  );
+}

--- a/src/Api/GraphQL/graphql.ts
+++ b/src/Api/GraphQL/graphql.ts
@@ -1,7 +1,17 @@
 import { ApiV3 } from '../Types';
-import { Result } from '../Types/GraphQL';
+import { Result, Data } from '../Types/GraphQL';
 
-export async function graphql<T>(query: string, variables?: {[key: string]: any}): Promise<ApiV3.HttpResponse<Result<T>>> {
+/**
+ * Queries the GraphQL API.
+ * @param query the GQL query
+ * @param variables named variables to substitute into the query, if any
+ * @returns the response from the API if successful
+ * @throws {HttpError} if it receives a non-2XX result
+ */
+export function graphql<T extends Data>(
+  query: string,
+  variables?: { [key: string]: any }
+): Promise<ApiV3.HttpResponse<Result<T>>> {
   return ApiV3.request(
     'POST',
     '/graphql',

--- a/src/Api/GraphQL/graphql.ts
+++ b/src/Api/GraphQL/graphql.ts
@@ -1,10 +1,10 @@
 import { ApiV3 } from '../Types';
 import { Result } from '../Types/GraphQL';
 
-export async function graphql<T>(query: string): Promise<ApiV3.HttpResponse<Result<T>>> {
+export async function graphql<T>(query: string, variables?: {[key: string]: any}): Promise<ApiV3.HttpResponse<Result<T>>> {
   return ApiV3.request(
     'POST',
     '/graphql',
-    { query }
+    { query, variables }
   );
 }

--- a/src/Api/GraphQL/graphql.ts
+++ b/src/Api/GraphQL/graphql.ts
@@ -1,20 +1,24 @@
 import { ApiV3 } from '../Types';
-import { Result, Data } from '../Types/GraphQL';
+import { GqlError, GqlHttpResponse, GqlExtensions } from '../Types/GraphQL';
+
+interface QueryResult<T extends ApiV3.V3Response> {
+  errors?: GqlError[];
+  data?: T;
+  extensions?: GqlExtensions;
+}
 
 /**
  * Queries the GraphQL API.
  * @param query the GQL query
  * @param variables named variables to substitute into the query, if any
- * @returns the response from the API if successful
+ * @returns {GqlHttpResponse} if successful
  * @throws {HttpError} if it receives a non-2XX result
  */
-export function graphql<T extends Data>(
+export async function graphql<T extends ApiV3.V3Response>(
   query: string,
   variables?: { [key: string]: any }
-): Promise<ApiV3.HttpResponse<Result<T>>> {
-  return ApiV3.request(
-    'POST',
-    '/graphql',
-    { query, variables }
-  );
+): Promise<GqlHttpResponse<T>> {
+  const response = await ApiV3.post<QueryResult<T>>('/graphql', { query, variables });
+  const { data, extensions, errors } = response.data;
+  return { ...response, data, extensions, errors };
 }

--- a/src/Api/Types/GraphQL.ts
+++ b/src/Api/Types/GraphQL.ts
@@ -1,0 +1,29 @@
+/**
+ * GraphQL response types.
+ * See: https://spec.graphql.org/October2021/#sec-Response
+ */
+
+interface Extensions {
+  [key: string]: string;
+}
+
+export interface Error {
+  message: string;
+  locations: [
+    {
+      line: number;
+      column: number;
+    }
+  ];
+  extensions?: Extensions;
+}
+
+/**
+ * The response format for a GraphQL request.
+ * `data` will be populated on success with given type T.
+ */
+export interface Result<T> {
+  errors?: Error[];
+  data?: T;
+  extensions?: Extensions;
+}

--- a/src/Api/Types/GraphQL.ts
+++ b/src/Api/Types/GraphQL.ts
@@ -18,11 +18,15 @@ export interface Error {
   extensions?: Extensions;
 }
 
+export interface Data {
+  [key: string]: any;
+}
+
 /**
  * The response format for a GraphQL request.
  * `data` will be populated on success with given type T.
  */
-export interface Result<T> {
+export interface Result<T extends Data> {
   errors?: Error[];
   data?: T;
   extensions?: Extensions;

--- a/src/Api/Types/GraphQL.ts
+++ b/src/Api/Types/GraphQL.ts
@@ -1,33 +1,59 @@
-/**
- * GraphQL response types.
- * See: https://spec.graphql.org/October2021/#sec-Response
- */
+import { Headers } from 'node-fetch';
+import { ApiV3 } from '.';
 
-interface Extensions {
+/**
+ * Additional information that may be returned by the GraphQL API.
+ * See: https://spec.graphql.org/October2021/#sec-Response-Format
+ */
+export interface GqlExtensions {
   [key: string]: string;
 }
 
-export interface Error {
+/**
+ * Error format for the GraphQL API.
+ * See [GQL Error spec](https://spec.graphql.org/October2021/#sec-Errors)
+ */
+export interface GqlError {
+  /**
+   * Description of the error.
+   */
   message: string;
+  /**
+   * A list of locations specifying where in the point in the document that caused the error.
+   */
   locations: [
     {
       line: number;
       column: number;
     }
   ];
-  extensions?: Extensions;
-}
-
-export interface Data {
-  [key: string]: any;
+  /**
+   * Additional information that may be returned by the GraphQL API.
+   */
+  extensions?: GqlExtensions;
 }
 
 /**
- * The response format for a GraphQL request.
- * `data` will be populated on success with given type T.
+ * Http response format for the GraphQL API. This is a variation of ApiV3.HttpResponse,
+ * extended to include the standard fields from a GraphQL request.
+ * See [GQL response data spec](https://spec.graphql.org/October2021/#sec-Data)
  */
-export interface Result<T extends Data> {
-  errors?: Error[];
-  data?: T;
-  extensions?: Extensions;
+export interface GqlHttpResponse<T extends ApiV3.V3Response> {
+  success: boolean;
+  status: number;
+  statusText: string;
+  headers: Headers;
+  /**
+   * The data returned by the query. Type T will be used to describe the data.
+   * (undefined and null are both valid values from the spec)
+   */
+  data?: T | null;
+  /**
+   * Any errors that might be returned by the GraphQL API.
+   */
+  errors?: GqlError[];
+  /**
+   * Any additional information that might be returned by the GraphQL API.
+   */
+  extensions?: GqlExtensions;
 }

--- a/src/Api/index.ts
+++ b/src/Api/index.ts
@@ -3,6 +3,7 @@ import {customer} from './Customers/customer';
 import {event} from './Events/event';
 import {identifier} from './Identifiers';
 import {ApiV3} from './lib/ApiV3';
+import {graphql} from './GraphQL/graphql';
 import {list} from './List';
 import {object} from './Objects/object';
 import {schema} from './Schema';
@@ -47,6 +48,10 @@ export const z = {
    * Manage customer identifiers using the v3 APIs
    */
   identifier,
+  /**
+   * Query data using the v3 GraphQL API
+   */
+  graphql,
   /**
    * Manage list subscriptions using the v3 APIs
    */

--- a/src/Api/index.ts
+++ b/src/Api/index.ts
@@ -49,7 +49,7 @@ export const z = {
    */
   identifier,
   /**
-   * Query data using the v3 GraphQL API
+   * Query data using the GraphQL API
    */
   graphql,
   /**


### PR DESCRIPTION
Since requests are routed through the v3 API, authentication is handled by the request interceptor by adding the `x-api-key` header.

A type must be provided in the call to `graphql` to describe the expected response.

https://zaius-jira.atlassian.net/browse/ZAIUS-14459

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaiusinc/node-sdk/47)
<!-- Reviewable:end -->
