### PR TITLE
OCP-811: allowing skipping gh packages release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
         required: true
         type: boolean
         default: true
+      release_to_github:
+        description: 'True to release to internal Github Packages registry'
+        required: true
+        type: boolean
+        default: true
 
 jobs:
   release:
@@ -18,3 +23,4 @@ jobs:
       gitReleasesToken: ${{ secrets.RELEASE_GITHUB_TOKEN }}
     with:
       release_to_npm: ${{ inputs.release_to_npm }}
+      release_to_github: ${{ inputs.release_to_github }}

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -8,6 +8,11 @@ on:
         required: true
         type: boolean
         default: true
+      release_to_github:
+        description: 'True to release to internal GitHub packages registry'
+        required: true
+        type: boolean
+        default: true
     secrets:
       npmJSToken:
         required: false
@@ -63,6 +68,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.gitReleasesToken }}
 
       - name: release-and-publish-to-github-packages
+        if: ${{ inputs.release_to_github }}
         run: |
           yarn publish --verbose --access restricted --registry https://npm.pkg.github.com
         env:


### PR DESCRIPTION
Checklist:

- [ ] internal documentation is up-to-date
- [ ] external documentation is up-to-date

