### PR TITLE
OCP-811: fixing publishing to npmjs.org

### DIFF
--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -74,6 +74,15 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.githubPackagesToken }}
 
+      # this step is required as 'yarn publish' ignores --registry flag if registry is defined in .npmrc
+      - name: Reconfigure NPM registry
+        uses: actions/setup-node@v4
+        with:
+          always-auth: true
+          node-version: '18.x'
+          registry-url: https://registry.npmjs.org
+          scope: '@zaiusinc'
+
       - name: release-and-publish-to-npm
         if: ${{ inputs.release_to_npm }}
         run: |


### PR DESCRIPTION
Checklist:

- [ ] internal documentation is up-to-date
- [ ] external documentation is up-to-date

