### PR TITLE
OCP-1705: allowing to specify tag for reusable-workflow

### DIFF
--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -13,6 +13,11 @@ on:
         required: true
         type: boolean
         default: true
+      release_tag: 
+        description: 'npmjs.com or/and github packages release tag - defaults to latest'
+        required: false
+        default: 'latest'
+        type: string
     secrets:
       githubPackagesToken:
         required: true
@@ -96,10 +101,12 @@ jobs:
       # requires connecting to GitHub repo and workflow in package settings in npmjs.com
       - name: release-and-publish-to-npm
         if: ${{ inputs.release_to_npm }}
+        env:
+          TAG: ${{ inputs.release_tag }}
         run: |
           version=$(cat package.json | jq -r .version)
           if [[ $version == *-* ]]; then
             echo "$version is tagged... Skipping publishing to npmjs"
           else 
-            npm publish --access public --registry https://registry.npmjs.org --verbose
+            npm publish --tag $TAG --access public --registry https://registry.npmjs.org --verbose
           fi


### PR DESCRIPTION
this will let us specify npmjs.com tags for certain branches

Checklist:

- [ ] internal documentation is up-to-date
- [ ] external documentation is up-to-date

