### PR TITLE
maintenance: allow node version input in reusable workflows

### DIFF
--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -2,6 +2,12 @@ name: reusable-build
 
 on:
   workflow_call:
+    inputs:
+      node_version:
+        description: 'Node.js version (e.g. 20.x). If empty, derived from package.json'
+        required: false
+        default: ''
+        type: string
     secrets:
       nodeAuthToken:
         required: true
@@ -15,13 +21,14 @@ jobs:
 
       - name: Determine Node.js version
         id: node
+        if: inputs.node_version == ''
         uses: ZaiusInc/node-sdk/.github/actions/determine-node-version@master
 
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           always-auth: true
-          node-version: ${{ env.node_version }}
+          node-version: ${{ inputs.node_version || env.node_version }}
           registry-url: https://npm.pkg.github.com
           scope: '@zaiusinc'
 

--- a/.github/workflows/reusable-rdme-docs.yaml
+++ b/.github/workflows/reusable-rdme-docs.yaml
@@ -4,6 +4,12 @@ name: reusable-readme-docs
 
 on:
   workflow_call:
+    inputs:
+      node_version:
+        description: 'Node.js version (e.g. 20.x). If empty, derived from package.json'
+        required: false
+        default: ''
+        type: string
     secrets:
       readmeApiKey:
         required: true
@@ -17,11 +23,12 @@ jobs:
 
       - name: Determine Node.js version
         id: node
+        if: inputs.node_version == ''
         uses: ZaiusInc/node-sdk/.github/actions/determine-node-version@master
 
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.node_version }}
+          node-version: ${{ inputs.node_version || env.node_version }}
           cache: 'yarn'
 
       - name: Install

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -13,10 +13,15 @@ on:
         required: true
         type: boolean
         default: true
-      release_tag: 
+      release_tag:
         description: 'npmjs.com or/and github packages release tag - defaults to latest'
         required: false
         default: 'latest'
+        type: string
+      node_version:
+        description: 'Node.js version (e.g. 20.x). If empty, derived from package.json'
+        required: false
+        default: ''
         type: string
     secrets:
       githubPackagesToken:
@@ -36,13 +41,14 @@ jobs:
 
       - name: Determine Node.js version
         id: node
+        if: inputs.node_version == ''
         uses: ZaiusInc/node-sdk/.github/actions/determine-node-version@master
 
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           always-auth: true
-          node-version: ${{ env.node_version }}
+          node-version: ${{ inputs.node_version || env.node_version }}
           registry-url: https://npm.pkg.github.com
           scope: '@zaiusinc'
 
@@ -90,7 +96,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           always-auth: true
-          node-version: ${{ env.node_version }}
+          node-version: ${{ inputs.node_version || env.node_version }}
           registry-url: https://registry.npmjs.org
           scope: '@zaiusinc'
 


### PR DESCRIPTION
## Summary

Adds optional `node_version` input to all three reusable workflows (`reusable-release`, `reusable-build`, `reusable-rdme-docs`). Callers can pin a specific Node.js version; when input omitted, existing `determine-node-version` script still runs as fallback. No behavior change for current callers.

## Test plan

- [ ] Push triggers existing `pr-watcher.yml` → confirm `Determine Node.js version` step still runs and resolves correct version
- [ ] On a throwaway branch, edit a caller to pass `node_version: 20.x` → confirm `Determine Node.js version` step is skipped and `setup-node` uses 20.x